### PR TITLE
ci: add support for multiple platforms in Docker build actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           load: true
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: ${{ github.repository }}:test
       - name: Test Docker image

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           provenance: mode=max
           tags: ${{ steps.metadata.outputs.tags }}
           cache-from: type=gha


### PR DESCRIPTION
**Fixed**

- Resolved issue where Docker images built for the `linux/arm64` platform were incorrectly detected as `unknown/unknown`