### PR TITLE
fixt: missconfigured dxt pack steps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,8 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: pnpm clean
+      - run: rm -rf node_modules
       - run: pnpm install --prod --frozen-lockfile --prefer-offline
+      - run: pnpm install -g @anthropic-ai/dxt
       - run: ./scripts/pack-dxt.sh
       - run: gh release upload ${{ github.ref_name }} prometheus-mcp.dxt


### PR DESCRIPTION
**Fixed**
Removes the `pnpm clean` step and instead directly removes the `node_modules` directory. This ensures a clean slate for the production dependencies installation.

Additionally, the script now installs the `@anthropic-ai/dxt` package globally, which is required for the DXT packaging step. These changes optimize the DXT packaging process and ensure all necessary dependencies are available.