### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 A Model Context Protocol (MCP) server that provides seamless integration between AI assistants and [Prometheus](https://prometheus.io/), enabling natural language interactions with your monitoring infrastructure. This server allows for effortless querying, discovery, and analysis of metrics through Visual Studio Code, Cursor, Windsurf, Claude Desktop, and other MCP clients.
 
+<a href="https://glama.ai/mcp/servers/@idanfishman/prometheus-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@idanfishman/prometheus-mcp/badge" alt="prometheus-mcp MCP server" />
+</a>
+
 </div>
 
 ## Key Features


### PR DESCRIPTION
This PR adds a badge for the [prometheus-mcp](https://glama.ai/mcp/servers/@idanfishman/prometheus-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@idanfishman/prometheus-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@idanfishman/prometheus-mcp/badge" alt="prometheus-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.